### PR TITLE
fix(mobile): teach mobile's `RequireHandlerImpl` to clean paths when desktop's does

### DIFF
--- a/src/Mobile/RequireHandler.ts
+++ b/src/Mobile/RequireHandler.ts
@@ -1,6 +1,6 @@
 import { CapacitorAdapter } from 'obsidian';
 
-import { RequireHandler } from '../RequireHandler.ts';
+import { RequireHandler, splitQuery } from '../RequireHandler.ts';
 
 class RequireHandlerImpl extends RequireHandler {
   private get capacitorAdapter(): CapacitorAdapter {
@@ -35,7 +35,7 @@ class RequireHandlerImpl extends RequireHandler {
   }
 
   protected override async getTimestampAsync(path: string): Promise<number> {
-    const stat = await this.capacitorAdapter.fs.stat(path);
+    const stat = await this.capacitorAdapter.fs.stat(splitQuery(path).cleanStr);
     return stat.mtime ?? 0;
   }
 


### PR DESCRIPTION
without this, `RequireHandler.requirePathAsync` on a path with trailing `?codeScriptName=…` will cause `RequireHandlerImpl.getTimestampAsync` to throw (assuming the file at the clean path exists without strangely named siblings) because the path *with* the trailing query does not exist.