### PR TITLE
feat: migrate settings to Obsidian 1.13 API

### DIFF
--- a/scripts/vitest-config.ts
+++ b/scripts/vitest-config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vitest/config';
 
 const SHARED_EXCLUDE = ['node_modules', 'dist'];
+const NO_WEBSTORAGE_EXEC_ARGV = process.allowedNodeEnvironmentFlags.has(
+    '--webstorage'
+  )
+  ? ['--no-webstorage']
+  : [];
 const BIG_TIMEOUT_IN_MILLISECONDS = 30_000;
 const ANDROID_TIMEOUT_IN_MILLISECONDS = 60_000;
 const PERFORMANCE_TIMEOUT_IN_MILLISECONDS = 600_000;
@@ -31,7 +36,7 @@ export const config = defineConfig({
         test: {
           environment: 'jsdom',
           exclude: [...SHARED_EXCLUDE, 'src/**/*.integration.test.ts'],
-          execArgv: ['--no-webstorage'],
+          execArgv: NO_WEBSTORAGE_EXEC_ARGV,
           include: ['src/**/*.test.ts'],
           name: 'unit-tests',
           server: {

--- a/src/plugin-settings-tab.ts
+++ b/src/plugin-settings-tab.ts
@@ -1,12 +1,19 @@
+import type { SettingDefinitionItem } from 'obsidian';
 import type { PluginSettingsTabBaseConstructorParams } from 'obsidian-dev-utils/obsidian/plugin/plugin-settings-tab';
 
 import {
   Events,
+  requireApiVersion,
   stringifyYaml
 } from 'obsidian';
 import { convertAsyncToSync } from 'obsidian-dev-utils/async';
+import { castTo } from 'obsidian-dev-utils/object-utils';
 import { appendCodeBlock } from 'obsidian-dev-utils/obsidian/html-element';
-import { PluginSettingsTabBase } from 'obsidian-dev-utils/obsidian/plugin/plugin-settings-tab';
+import {
+  PluginSettingsTabBase,
+  SAVE_TO_FILE_CONTEXT
+} from 'obsidian-dev-utils/obsidian/plugin/plugin-settings-tab';
+import { CodeHighlighterComponent } from 'obsidian-dev-utils/obsidian/setting-components/code-highlighter-component';
 import { SettingGroupEx } from 'obsidian-dev-utils/obsidian/setting-group-ex';
 import { EMPTY } from 'obsidian-dev-utils/string';
 import { ValueWrapper } from 'obsidian-dev-utils/value-wrapper';
@@ -19,6 +26,8 @@ import { PathSuggest } from './path-suggest.ts';
 interface PluginSettingsTabConstructorParams extends PluginSettingsTabBaseConstructorParams<PluginSettings> {
   readonly pluginName: string;
 }
+
+type PluginSettingsKey = Exclude<keyof PluginSettings, 'getInvocableScriptsFolder' | 'getStartupScriptPath'>;
 
 export class PluginSettingsTab extends PluginSettingsTabBase<PluginSettings> {
   private readonly pluginName: string;
@@ -246,5 +255,276 @@ export class PluginSettingsTab extends PluginSettingsTabBase<PluginSettings> {
             this.bind({ propertyName: 'shouldShowTempPluginLoadUnloadNotices', valueComponent: toggle });
           });
       });
+  }
+
+  public override getControlValue(key: string): unknown {
+    const settings = this.pluginSettingsComponent.settingsState.inputValues;
+    if (!Object.hasOwn(settings, key)) {
+      return undefined;
+    }
+
+    return settings[castTo<PluginSettingsKey>(key)];
+  }
+
+  public override getSettingDefinitions(): SettingDefinitionItem<PluginSettingsKey>[] {
+    if (!requireApiVersion('1.13.0')) {
+      return [];
+    }
+
+    const events = new Events();
+    const thisWrapper = ValueWrapper.of(this);
+    const MAX_INTERVAL_FOR_SET_TIMEOUT = 2147483647;
+    const MILLISECONDS_IN_SECOND = 1000;
+    const MAX_CHECKING_INTERVAL_IN_SECONDS = MAX_INTERVAL_FOR_SET_TIMEOUT / MILLISECONDS_IN_SECOND;
+
+    return [
+      {
+        heading: 'Paths',
+        items: [
+          {
+            desc: createFragment((f) => {
+              f.appendText('Path to the folder that is considered as ');
+              appendCodeBlock(f, '/');
+              f.appendText(' in ');
+              appendCodeBlock(f, 'require("/script.js")');
+              f.createEl('br');
+              f.appendText('Leave blank to use the root of the vault.');
+            }),
+            name: 'Script modules root',
+            render: (setting): void => {
+              setting.addText((text) => {
+                text
+                  .setPlaceholder(`${EMPTY}path/to/script/modules/root`)
+                  .setValue(this.pluginSettingsComponent.settingsState.inputValues.modulesRoot)
+                  .onChange(convertAsyncToSync(async (value) => {
+                    await this.setRenderedControlValue('modulesRoot', value, text.inputEl);
+                    events.trigger('modulesRootChanged');
+                  }));
+
+                new PathSuggest({
+                  app: this.app,
+                  getRootPath(): string {
+                    return '';
+                  },
+                  textInputEl: text.inputEl,
+                  type: 'folder'
+                });
+              });
+            }
+          },
+          {
+            desc: createFragment((f) => {
+              f.appendText('Path to the folder with invocable scripts.');
+              f.createEl('br');
+              f.appendText('Should be a relative path to the ');
+              appendCodeBlock(f, 'Script modules root');
+              f.createEl('br');
+              f.appendText('Leave blank if you don\'t use invocable scripts.');
+            }),
+            name: 'Invocable scripts folder',
+            render: (setting): void => {
+              setting.addText((text) => {
+                text
+                  .setPlaceholder(`${EMPTY}path/to/invocable/scripts/folder`)
+                  .setValue(this.pluginSettingsComponent.settingsState.inputValues.invocableScriptsFolder)
+                  .onChange(convertAsyncToSync((value) => this.setRenderedControlValue('invocableScriptsFolder', value, text.inputEl)));
+
+                const suggest = new PathSuggest({
+                  app: this.app,
+                  getRootPath(): string {
+                    return thisWrapper.value.pluginSettingsComponent.settings.modulesRoot;
+                  },
+                  textInputEl: text.inputEl,
+                  type: 'folder'
+                });
+
+                events.on('modulesRootChanged', () => {
+                  text.onChanged();
+                  suggest.refresh();
+                });
+              });
+            }
+          },
+          {
+            desc: createFragment((f) => {
+              f.appendText('Path to the invocable script executed on startup.');
+              f.createEl('br');
+              f.appendText('Should be a relative path to the ');
+              appendCodeBlock(f, 'Script modules root');
+              f.createEl('br');
+              f.appendText('Leave blank if you don\'t use startup script.');
+            }),
+            name: 'Startup script path',
+            render: (setting): void => {
+              setting.addText((text) => {
+                text
+                  .setPlaceholder('path/to/startup.ts')
+                  .setValue(this.pluginSettingsComponent.settingsState.inputValues.startupScriptPath)
+                  .onChange(convertAsyncToSync((value) => this.setRenderedControlValue('startupScriptPath', value, text.inputEl)));
+
+                const suggest = new PathSuggest({
+                  app: this.app,
+                  getRootPath(): string {
+                    return thisWrapper.value.pluginSettingsComponent.settings.modulesRoot;
+                  },
+                  textInputEl: text.inputEl,
+                  type: 'file'
+                });
+
+                events.on('modulesRootChanged', () => {
+                  text.onChanged();
+                  suggest.refresh();
+                });
+              });
+            }
+          }
+        ],
+        type: 'group'
+      },
+      {
+        heading: 'Desktop',
+        items: [
+          {
+            control: { key: 'shouldUseSyncFallback', type: 'toggle' },
+            desc: createFragment((f) => {
+              f.appendText('Whether to use a synchronous ');
+              appendCodeBlock(f, 'require()');
+              f.appendText(' fallback if ');
+              appendCodeBlock(f, 'requireAsync()');
+              f.appendText(' failed ');
+              f.createEl('strong', { text: '(Only on desktop)' });
+              f.appendText('.');
+            }),
+            name: 'Desktop: Synchronous fallback'
+          }
+        ],
+        type: 'group'
+      },
+      {
+        heading: 'Mobile',
+        items: [
+          {
+            control: {
+              key: 'mobileChangesCheckingIntervalInSeconds',
+              max: MAX_CHECKING_INTERVAL_IN_SECONDS,
+              min: 0,
+              type: 'number'
+            },
+            desc: createFragment((f) => {
+              f.appendText('Interval in seconds to check for changes in the invocable scripts folder ');
+              f.createEl('strong', { text: '(Only on mobile)' });
+              f.appendText('.');
+              f.createEl('br');
+              f.appendText('Set ');
+              appendCodeBlock(f, '0');
+              f.appendText(' to disable checking for changes.');
+            }),
+            name: 'Mobile: Changes checking interval'
+          }
+        ],
+        type: 'group'
+      },
+      {
+        heading: 'Code button blocks',
+        items: [
+          {
+            desc: createFragment((f) => {
+              f.appendText('Default configuration applied to ');
+              appendCodeBlock(f, '```code-button');
+              f.appendText(' blocks.');
+            }),
+            name: 'Default code button config',
+            render: (setting): void => {
+              const codeHighlighter = new CodeHighlighterComponent(setting.controlEl);
+              codeHighlighter
+                .setLanguage('yaml')
+                .setValue(this.pluginSettingsComponent.settingsState.inputValues.defaultCodeButtonConfig)
+                .onChange(convertAsyncToSync((value) => this.setRenderedControlValue('defaultCodeButtonConfig', value, codeHighlighter.inputEl)));
+              codeHighlighter.inputEl.addClass('default-code-button-config-control');
+            }
+          },
+          {
+            name: 'Reset default code button config',
+            render: (setting): void => {
+              setting.addButton((button) =>
+                button
+                  .setButtonText('Reset to plugin default code button config')
+                  .setWarning()
+                  .onClick(convertAsyncToSync(async () => {
+                    await this.pluginSettingsComponent.editAndSave((settings) => {
+                      const yaml = stringifyYaml(DEFAULT_CODE_BUTTON_BLOCK_CONFIG);
+                      settings.defaultCodeButtonConfig = `---\n${yaml}---`;
+                    });
+
+                    if (requireApiVersion('1.13.0')) {
+                      this.update();
+                    }
+                  }))
+              );
+            }
+          }
+        ],
+        type: 'group'
+      },
+      {
+        heading: 'Other',
+        items: [
+          {
+            desc: 'Hotkeys to invoke scripts.',
+            name: 'Hotkeys',
+            render: (setting): void => {
+              setting.addButton((button) =>
+                button
+                  .setButtonText('Configure')
+                  .setTooltip('Configure hotkeys')
+                  .onClick(() => {
+                    const hotkeysTab = this.app.setting.openTabById('hotkeys');
+                    hotkeysTab.searchComponent.setValue(`${this.pluginName}:`);
+                    hotkeysTab.updateHotkeyVisibility();
+                  })
+              );
+            }
+          },
+          {
+            control: { key: 'shouldHandleProtocolUrls', type: 'toggle' },
+            desc: createFragment((f) => {
+              f.appendText('Whether to handle protocol URLs: ');
+              appendCodeBlock(f, 'obsidian://CodeScriptToolkit?...');
+              f.createEl('br');
+              f.appendText('⚠️ WARNING: This allows arbitrary code execution, which could pose a security risk. Use with caution.');
+            }),
+            name: 'Handle protocol URLs'
+          },
+          {
+            control: { key: 'shouldShowTempPluginLoadUnloadNotices', type: 'toggle' },
+            desc: 'Whether to show notices when the temp plugins are loaded/unloaded.',
+            name: 'Should show temp plugin load/unload notices'
+          }
+        ],
+        type: 'group'
+      }
+    ];
+  }
+
+  public override async setControlValue(key: string, value: unknown): Promise<void> {
+    const settings = this.pluginSettingsComponent.settingsState.inputValues;
+    if (!Object.hasOwn(settings, key)) {
+      return;
+    }
+
+    const propertyName = castTo<PluginSettingsKey>(key);
+    await this.pluginSettingsComponent.setProperty(propertyName, castTo<PluginSettings[typeof propertyName]>(value));
+    await this.pluginSettingsComponent.saveToFile(SAVE_TO_FILE_CONTEXT);
+  }
+
+  private async setRenderedControlValue<PropertyName extends PluginSettingsKey>(
+    propertyName: PropertyName,
+    value: PluginSettings[PropertyName],
+    inputEl: HTMLInputElement | HTMLTextAreaElement
+  ): Promise<void> {
+    const validationMessage = await this.pluginSettingsComponent.setProperty(propertyName, value);
+    inputEl.setCustomValidity(validationMessage);
+    inputEl.reportValidity();
+    await this.pluginSettingsComponent.saveToFile(SAVE_TO_FILE_CONTEXT);
   }
 }


### PR DESCRIPTION
## Summary

- Add guarded `getSettingDefinitions()` support for Obsidian 1.13 while retaining the legacy `display()` fallback.
- Preserve save/update behavior, including the 1.13 settings-tab update path.
- Use compile-safe callback and utility types for the new definitions.
- Make Vitest worker arguments compatible with Node versions that do not expose the webstorage flag.

## Testing

- [x] All 845 Vitest tests pass.
- [x] Typecheck, lint, and production build pass.
- [ ] Run the repository-wide `format:check` command before opening.
- [ ] Run the repository-wide `spellcheck` command before opening.